### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ JSONPatchSwift is an implementation of JSONPatch (RFC 6902) in pure Swift.
 ## Installation
 
 ###CocoaPods (iOS 9.0+, OS X 10.10+)
-You can use [Cocoapods](http://cocoapods.org/) to install `JSONPatchSwift`by adding it to your `Podfile`:
+You can use [CocoaPods](http://cocoapods.org/) to install `JSONPatchSwift`by adding it to your `Podfile`:
 ```ruby
 platform :ios, '9.0'
 use_frameworks!


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
